### PR TITLE
Undo snackbar

### DIFF
--- a/app/src/main/java/com/woefe/shoppinglist/activity/RecyclerListAdapter.java
+++ b/app/src/main/java/com/woefe/shoppinglist/activity/RecyclerListAdapter.java
@@ -31,7 +31,7 @@ public class RecyclerListAdapter extends RecyclerView.Adapter<RecyclerListAdapte
     private ShoppingList shoppingList;
     private ItemTouchHelper touchHelper;
     private ItemLongClickListener longClickListener;
-    private View view;
+    private View snackbarView;
 
     private final ShoppingList.ShoppingListListener listener = new ShoppingList.ShoppingListListener() {
         @Override
@@ -60,7 +60,7 @@ public class RecyclerListAdapter extends RecyclerView.Adapter<RecyclerListAdapte
         colorDefault = ContextCompat.getColor(ctx, R.color.textColorDefault);
         colorBackground = ContextCompat.getColor(ctx, R.color.colorListItemBackground);
         touchHelper = new ItemTouchHelper(new RecyclerListCallback(ctx));
-        view = ((Activity) ctx).findViewById(R.id.fab_add_parent);
+        snackbarView = ((Activity) ctx).findViewById(R.id.fab_add_parent);
     }
 
     public void connectShoppingList(ShoppingList shoppingList) {
@@ -83,7 +83,7 @@ public class RecyclerListAdapter extends RecyclerView.Adapter<RecyclerListAdapte
     public void remove(int pos) {
         final int lastDeletedPosition = pos;
         final ListItem lastDeletedItem = shoppingList.remove(pos);
-        Snackbar.make(view, R.string.item_deleted, Snackbar.LENGTH_LONG)
+        Snackbar.make(snackbarView, R.string.item_deleted, Snackbar.LENGTH_LONG)
                 .setAction(R.string.undo_delete, new View.OnClickListener() {
                     @Override
                     public void onClick(View v) {

--- a/app/src/main/java/com/woefe/shoppinglist/activity/RecyclerListAdapter.java
+++ b/app/src/main/java/com/woefe/shoppinglist/activity/RecyclerListAdapter.java
@@ -1,10 +1,12 @@
 package com.woefe.shoppinglist.activity;
 
+import android.app.Activity;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.support.annotation.NonNull;
+import android.support.design.widget.Snackbar;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.helper.ItemTouchHelper;
@@ -29,6 +31,7 @@ public class RecyclerListAdapter extends RecyclerView.Adapter<RecyclerListAdapte
     private ShoppingList shoppingList;
     private ItemTouchHelper touchHelper;
     private ItemLongClickListener longClickListener;
+    private View view;
 
     private final ShoppingList.ShoppingListListener listener = new ShoppingList.ShoppingListListener() {
         @Override
@@ -57,6 +60,7 @@ public class RecyclerListAdapter extends RecyclerView.Adapter<RecyclerListAdapte
         colorDefault = ContextCompat.getColor(ctx, R.color.textColorDefault);
         colorBackground = ContextCompat.getColor(ctx, R.color.colorListItemBackground);
         touchHelper = new ItemTouchHelper(new RecyclerListCallback(ctx));
+        view = ((Activity) ctx).findViewById(R.id.fab_add_parent);
     }
 
     public void connectShoppingList(ShoppingList shoppingList) {
@@ -77,7 +81,15 @@ public class RecyclerListAdapter extends RecyclerView.Adapter<RecyclerListAdapte
     }
 
     public void remove(int pos) {
-        shoppingList.remove(pos);
+        final int lastDeletedPosition = pos;
+        final ListItem lastDeletedItem = shoppingList.remove(pos);
+        Snackbar.make(view, R.string.item_deleted, Snackbar.LENGTH_LONG)
+                .setAction(R.string.undo_delete, new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        shoppingList.add(lastDeletedPosition, lastDeletedItem);
+                    }
+                }).show();
     }
 
     public void registerRecyclerView(RecyclerView view) {

--- a/app/src/main/res/layout/fragment_shoppinglist.xml
+++ b/app/src/main/res/layout/fragment_shoppinglist.xml
@@ -19,7 +19,6 @@
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/content"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
@@ -29,7 +28,7 @@
         android:id="@+id/shoppingListView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_above="@+id/layout_add_item"
+        android:layout_above="@id/layout_add_item"
         android:layout_alignParentEnd="true"
         android:scrollbars="vertical" />
 
@@ -39,7 +38,7 @@
         android:id="@+id/fab_add_parent"
         android:layout_width="match_parent"
         android:layout_height="125dp"
-        android:layout_alignEnd="@+id/shoppingListView"
+        android:layout_alignEnd="@id/shoppingListView"
         android:layout_alignParentBottom="true"
         android:layout_gravity="bottom">
 
@@ -100,7 +99,7 @@
             android:layout_height="wrap_content"
             android:layout_alignParentStart="true"
             android:layout_below="@id/new_item_description"
-            android:layout_toStartOf="@+id/button_add_new_item"
+            android:layout_toStartOf="@id/button_add_new_item"
             android:hint="@string/hint_quantity"
             android:inputType="textCapSentences"
             android:singleLine="true" />

--- a/app/src/main/res/layout/fragment_shoppinglist.xml
+++ b/app/src/main/res/layout/fragment_shoppinglist.xml
@@ -19,6 +19,7 @@
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/content"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
@@ -32,17 +33,26 @@
         android:layout_alignParentEnd="true"
         android:scrollbars="vertical" />
 
-    <android.support.design.widget.FloatingActionButton
-        android:id="@+id/fab_add"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+    <!-- The fixed height is a workaround to prevent the top of
+         the FAB disappearing when a snackbar moves in -->
+    <android.support.design.widget.CoordinatorLayout
+        android:id="@+id/fab_add_parent"
+        android:layout_width="match_parent"
+        android:layout_height="125dp"
         android:layout_alignEnd="@+id/shoppingListView"
         android:layout_alignParentBottom="true"
-        android:layout_gravity="bottom|end"
-        android:layout_margin="16dp"
-        android:clickable="true"
-        android:focusable="true"
-        android:src="@drawable/ic_add_black_24dp" />
+        android:layout_gravity="bottom">
+
+        <android.support.design.widget.FloatingActionButton
+            android:id="@+id/fab_add"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom|end"
+            android:layout_margin="16dp"
+            android:clickable="true"
+            android:focusable="true"
+            android:src="@drawable/ic_add_black_24dp" />
+    </android.support.design.widget.CoordinatorLayout>
 
     <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
         android:id="@+id/layout_add_item"

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -40,6 +40,8 @@
     <string name="done">Fertig</string>
     <string name="swap">Tauschen</string>
     <string name="fragment_invalid_text">Es sind keine Listen vorhanden.</string>
+    <string name="item_deleted">Eintrag gelöscht</string>
+    <string name="undo_delete">RÜCKGÄNGIG</string>
     <string name="lists">Listen</string>
     <string name="about">Über</string>
     <string name="error_list_name_empty">Der Listenname darf nicht leer sein!</string>
@@ -66,5 +68,5 @@
     <string name="about_github">&lt;h3&gt;Quellcode, Probleme, Mitmachen&lt;/h3&gt; Dieses Projekt wird auf &lt;a href=&quot;https://github.com/woefe/ShoppingList&quot;&gt;Github&lt;/a&gt; verwaltet.</string>
     <string name="about_license">&lt;h3&gt;Lizenz&lt;/h3&gt; ShoppingList unter &lt;a href=&quot;https://raw.githubusercontent.com/woefe/ShoppingList/master/COPYING&quot;&gt;GPLv3+&lt;/a&gt; lizenziert.</string>
     <string name="about_author">&lt;h3&gt;Autor&lt;/h3&gt; Wolfgang Popp</string>
-    <string name="about_contributors">&lt;h3&gt;Mitwirkende&lt;/h3&gt; &#8226; &lt;b&gt;Pierre Rudloff&lt;/b&gt; (Französische Übersetzung)&lt;br/&gt; &#8226; &lt;b&gt;unbranched&lt;/b&gt; (Italienische Übersetzung)&lt;br/&gt;</string>
+    <string name="about_contributors">&lt;h3&gt;Mitwirkende&lt;/h3&gt; &#8226; &lt;b&gt;Pierre Rudloff&lt;/b&gt; (Französische Übersetzung)&lt;br/&gt; &#8226; &lt;b&gt;unbranched&lt;/b&gt; (Italienische Übersetzung)&lt;br/&gt; &#8226; &lt;b&gt;Nuntius&lt;/b&gt; &lt;br/&gt;</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -66,5 +66,5 @@
     <string name="about_github">&lt;h3&gt;Code source, rapports de bug et contribution&lt;/h3&gt; Ce projet est h&#xE9;berg&#xE9; sur &lt;a href="https://github.com/woefe/ShoppingList"&gt;Github&lt;/a&gt;</string>
     <string name="about_license">&lt;h3&gt;Licence&lt;/h3&gt; ShoppingList est publi&#xE9; sous licence &lt;a href="https://raw.githubusercontent.com/woefe/ShoppingList/master/COPYING"&gt;GPLv3+&lt;/a&gt;</string>
     <string name="about_author">&lt;h3&gt;Auteur&lt;/h3&gt; Wolfgang Popp</string>
-    <string name="about_contributors">&lt;h3&gt;Contributeurs&lt;/h3&gt; &#8226; &lt;b&gt;Pierre Rudloff&lt;/b&gt; (traduction fran&#231;aise)&lt;br/&gt;&#8226; &lt;b&gt;unbranched&lt;/b&gt; (traduction italien)&lt;br/&gt;</string>
+    <string name="about_contributors">&lt;h3&gt;Contributeurs&lt;/h3&gt; &#8226; &lt;b&gt;Pierre Rudloff&lt;/b&gt; (traduction fran&#231;aise)&lt;br/&gt;&#8226; &lt;b&gt;unbranched&lt;/b&gt; (traduction italien)&lt;br/&gt; &#8226; &lt;b&gt;Nuntius&lt;/b&gt; &lt;br/&gt;</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -66,5 +66,5 @@
     <string name="about_github">&lt;h3&gt;Codice sorgente, problemi, contributi&lt;/h3&gt; Questo progetto viene ospitato su &lt;a href="https://github.com/woefe/ShoppingList"&gt;Github&lt;/a&gt;</string>
     <string name="about_license">&lt;h3&gt;Licenza&lt;/h3&gt; ShoppingList è concesso in licenza &lt;a href=&quot;https://raw.githubusercontent.com/woefe/ShoppingList/master/COPYING&quot;&gt;GPLv3+&lt;/a&gt;</string>
     <string name="about_author">&lt;h3&gt;Autore&lt;/h3&gt; Wolfgang Popp</string>
-    <string name="about_contributors">&lt;h3&gt;Collaboratori&lt;/h3&gt; &#8226; &lt;b&gt;Pierre Rudloff&lt;/b&gt; (traduzione in francese)&lt;br/&gt; &#8226; &lt;b&gt;unbranched&lt;/b&gt; (traduzione in italiano)&lt;br/&gt;</string>
+    <string name="about_contributors">&lt;h3&gt;Collaboratori&lt;/h3&gt; &#8226; &lt;b&gt;Pierre Rudloff&lt;/b&gt; (traduzione in francese)&lt;br/&gt; &#8226; &lt;b&gt;unbranched&lt;/b&gt; (traduzione in italiano)&lt;br/&gt; &#8226; &lt;b&gt;Nuntius&lt;/b&gt; &lt;br/&gt;</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -66,5 +66,5 @@
     <string name="about_github">&lt;h3&gt;Исходный код, Проблемы, Содействие&lt;/h3&gt; Этот проект находится на &lt;a href="https://github.com/woefe/ShoppingList"&gt;Github&lt;/a&gt;</string>
     <string name="about_license">&lt;h3&gt;Лицензия&lt;/h3&gt; ShoppingList лицензируется согласно &lt;a href=&quot;https://raw.githubusercontent.com/woefe/ShoppingList/master/COPYING&quot;&gt;GPLv3+&lt;/a&gt;</string>
     <string name="about_author">&lt;h3&gt;Автор&lt;/h3&gt; Wolfgang Popp</string>
-    <string name="about_contributors">&lt;h3&gt;Внёсшие вклад&lt;/h3&gt; &#8226; &lt;b&gt;Pierre Rudloff&lt;/b&gt; (перевод на французский)&lt;br/&gt;</string>
+    <string name="about_contributors">&lt;h3&gt;Внёсшие вклад&lt;/h3&gt; &#8226; &lt;b&gt;Pierre Rudloff&lt;/b&gt; (перевод на французский)&lt;br/&gt; &#8226; &lt;b&gt;Nuntius&lt;/b&gt; &lt;br/&gt;</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,6 +38,8 @@
     <string name="add_new_list">Add a new list</string>
     <string name="add_list_hint">Name of new list</string>
     <string name="fragment_invalid_text">No lists are available.</string>
+    <string name="item_deleted">Item deleted</string>
+    <string name="undo_delete">UNDO</string>
     <string name="done">Done</string>
     <string name="swap">Swap</string>
     <string name="lists">Lists</string>
@@ -66,5 +68,5 @@
     <string name="about_github">&lt;h3&gt;Source code, Issues, Contributing&lt;/h3&gt; This project is hosted on &lt;a href="https://github.com/woefe/ShoppingList"&gt;Github&lt;/a&gt;</string>
     <string name="about_license">&lt;h3&gt;License&lt;/h3&gt; ShoppingList is licensed under &lt;a href=&quot;https://raw.githubusercontent.com/woefe/ShoppingList/master/COPYING&quot;&gt;GPLv3+&lt;/a&gt;</string>
     <string name="about_author">&lt;h3&gt;Author&lt;/h3&gt; Wolfgang Popp</string>
-    <string name="about_contributors">&lt;h3&gt;Contributors&lt;/h3&gt; &#8226; &lt;b&gt;Pierre Rudloff&lt;/b&gt; (French translation)&lt;br/&gt; &#8226; &lt;b&gt;unbranched&lt;/b&gt; (Italian translation)&lt;br/&gt;</string>
+    <string name="about_contributors">&lt;h3&gt;Contributors&lt;/h3&gt; &#8226; &lt;b&gt;Pierre Rudloff&lt;/b&gt; (French translation)&lt;br/&gt; &#8226; &lt;b&gt;unbranched&lt;/b&gt; (Italian translation)&lt;br/&gt; &#8226; &lt;b&gt;Nuntius&lt;/b&gt; &lt;br/&gt;</string>
 </resources>


### PR DESCRIPTION
Fixes #29.

The FAB needs to be wrapped in a parent CoordinatorLayout and the snackbar needs to be called on this parent instead of the bigger `content_frame`, otherwise the snackbar will overlay the FAB.
With the CoordinatorLayout, the FAB moves up as you expect it.
However if you use `layout_height=wrap_content` for the fabParent, then the FAB's top half will disappear when the snackbar comes in. Thus as a workaround I fixed the height manually.

Strings for French, Italian and Russian are not yet translated.

Also, I took the liberty to add myself to the list of contributors :)