### PR TITLE
Only group checked items together; do not reorder alphabetically.

### DIFF
--- a/app/src/main/java/com/woefe/shoppinglist/activity/MainActivity.java
+++ b/app/src/main/java/com/woefe/shoppinglist/activity/MainActivity.java
@@ -278,7 +278,9 @@ public class MainActivity extends BinderActivity implements
                 if (!o1.isChecked() && o2.isChecked()) {
                     return checkedFirst ? -1 : 1;
                 }
-                return o1.getDescription().compareToIgnoreCase(o2.getDescription());
+                // Maintain the separate ordering of the checked items and the unchecked items
+                // return o1.getDescription().compareToIgnoreCase(o2.getDescription());
+                return 1;
             }
         });
 


### PR DESCRIPTION
I use this Shopping List app almost every day. Good job and thanks to @woefe ! 

When I compose my grocery shopping list, I put the items in the order that I will walk through the store, minimizing wasted time walking back and forth between aisles. I like to use the reorder button that puts the checked items at the bottom of the list sometimes so I don't have to scroll, but when I do this it alphabetizes the checked items and I lose my desired ordering! 

This simple pull request solves this problem. My testing was limited to one example list running in an Android virtual device via Android Studio.